### PR TITLE
wip: spanifying - previewing what merge's would look like

### DIFF
--- a/libs/cluster/Server/ClusterManager.cs
+++ b/libs/cluster/Server/ClusterManager.cs
@@ -322,10 +322,10 @@ namespace Garnet.cluster
             FlushConfig();
         }
 
-        private bool slotBitmapGetBit(ref byte[] bitmap, int pos)
+        private static bool SlotBitmapIsBitSet(ReadOnlySpan<byte> bitmap, int bitPosition)
         {
-            int BYTE = (pos / 8);
-            int BIT = pos & 7;
+            int BYTE = (bitPosition / 8);
+            int BIT = bitPosition & 7;
             return (bitmap[BYTE] & (1 << BIT)) != 0;
         }
 
@@ -337,7 +337,7 @@ namespace Garnet.cluster
         /// <param name="requestedEpoch"></param>
         /// <param name="claimedSlots"></param>
         /// <returns></returns>
-        public bool AuthorizeFailover(string requestingNodeId, long requestedEpoch, byte[] claimedSlots)
+        public bool AuthorizeFailover(string requestingNodeId, long requestedEpoch, ReadOnlySpan<byte> claimedSlots)
         {
             while (true)
             {
@@ -360,7 +360,7 @@ namespace Garnet.cluster
                 //Check if configEpoch for claimed slots is lower than the config of the requested epoch.
                 for (int i = 0; i < ClusterConfig.MAX_HASH_SLOT_VALUE; i++)
                 {
-                    if (slotBitmapGetBit(ref claimedSlots, i)) continue;
+                    if (SlotBitmapIsBitSet(claimedSlots, i)) continue;
                     if (current.GetConfigEpochFromSlot(i) < requestedEpoch) continue;
                     return false;
                 }

--- a/libs/cluster/Session/ClusterCommands.cs
+++ b/libs/cluster/Session/ClusterCommands.cs
@@ -415,8 +415,8 @@ namespace Garnet.cluster
                     {
                         if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var withMeet, ref ptr, recvBufferPtr + bytesRead))
                             return false;
-                        Debug.Assert(withMeet.SequenceEqual(CmdStrings.WITHMEET.ToArray()));
-                        if (withMeet.SequenceEqual(CmdStrings.WITHMEET.ToArray()))
+                        Debug.Assert(withMeet.SequenceEqual(CmdStrings.WITHMEET));
+                        if (withMeet.SequenceEqual(CmdStrings.WITHMEET))
                             gossipWithMeet = true;
                     }
 
@@ -430,7 +430,7 @@ namespace Garnet.cluster
                     // Try merge if not just a ping message
                     if (gossipMessage.Length > 0)
                     {
-                        var other = ClusterConfig.FromByteArray(gossipMessage);
+                        var other = ClusterConfig.FromByteArray(gossipMessage.ToArray());
                         // Accept gossip message if it is a gossipWithMeet or node from node that is already known and trusted
                         // GossipWithMeet messages are only send through a call to CLUSTER MEET at the remote node
                         if (gossipWithMeet || current.IsKnown(other.GetLocalNodeId()))
@@ -1444,7 +1444,7 @@ namespace Garnet.cluster
                     return false;
                 readHead = (int)(ptr - recvBufferPtr);
 
-                var remoteEntry = CheckpointEntry.FromByteArray(cEntryByteArray);
+                var remoteEntry = CheckpointEntry.FromByteArray(cEntryByteArray.ToArray());
                 var resp = clusterProvider.replicationManager.BeginReplicaSyncSession(nodeId, primary_replid, remoteEntry, replicaAofBeginAddress, replicaAofTailAddress);
                 while (!RespWriteUtils.WriteDirect(resp, ref dcurr, dend))
                     SendAndReset();
@@ -1462,7 +1462,7 @@ namespace Garnet.cluster
 
                 var fileToken = new Guid(fileTokenBytes);
                 var fileType = (CheckpointFileType)fileTypeInt;
-                clusterProvider.replicationManager.ProcessCheckpointMetadata(fileToken, fileType, checkpointMetadata);
+                clusterProvider.replicationManager.ProcessCheckpointMetadata(fileToken, fileType, checkpointMetadata.ToArray());
                 while (!RespWriteUtils.WriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
                     SendAndReset();
             }
@@ -1511,7 +1511,7 @@ namespace Garnet.cluster
                     return false;
                 readHead = (int)(ptr - recvBufferPtr);
 
-                var entry = CheckpointEntry.FromByteArray(cEntryByteArray);
+                var entry = CheckpointEntry.FromByteArray(cEntryByteArray.ToArray());
                 var replicationOffset = clusterProvider.replicationManager.BeginReplicaRecover(
                     recoverMainStoreFromToken,
                     recoverObjectStoreFromToken,

--- a/libs/cluster/Session/ClusterSlotCheck.cs
+++ b/libs/cluster/Session/ClusterSlotCheck.cs
@@ -82,7 +82,7 @@ namespace Garnet.cluster
         /// </summary>
         /// <returns>True if redirect, False if can serve</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool NetworkSingleKeySlotVerify(byte[] key, bool readOnly, byte SessionAsking, ref byte* dcurr, ref byte* dend)
+        public bool NetworkSingleKeySlotVerify(ReadOnlySpan<byte> key, bool readOnly, byte SessionAsking, ref byte* dcurr, ref byte* dend)
         {
             fixed (byte* keyPtr = key)
                 return NetworkSingleKeySlotVerify(new ArgSlice(keyPtr, key.Length), readOnly, SessionAsking, ref dcurr, ref dend);

--- a/libs/common/RespReadUtils.cs
+++ b/libs/common/RespReadUtils.cs
@@ -197,7 +197,7 @@ namespace Garnet.common
         /// <summary>
         /// Read byte array with length header
         /// </summary>
-        public static bool ReadByteArrayWithLengthHeader(out byte[] result, ref byte* ptr, byte* end)
+        public static bool ReadByteArrayWithLengthHeader(out ReadOnlySpan<byte> result, ref byte* ptr, byte* end)
         {
             result = null;
             if (ptr + 3 >= end)
@@ -231,7 +231,7 @@ namespace Garnet.common
             Debug.Assert(*(ptr - 2) == '\r');
             Debug.Assert(*(ptr - 1) == '\n');
 
-            result = new Span<byte>(keyPtr, ksize).ToArray();
+            result = new ReadOnlySpan<byte>(keyPtr, ksize);
             return true;
         }
 

--- a/libs/common/RespReadUtils.cs
+++ b/libs/common/RespReadUtils.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -431,41 +430,6 @@ namespace Garnet.common
         }
 
         /// <summary>
-        /// Read array with length header
-        /// </summary>
-        public static bool ReadArrayWithLengthHeader(out byte[][] result, ref byte* ptr, byte* end)
-        {
-            result = null;
-            if (ptr + 3 >= end)
-                return false;
-
-            Debug.Assert(*ptr == '*');
-            ptr++;
-            bool neg = *ptr == '-';
-            int asize = *ptr++ - '0';
-            while (*ptr != '\r')
-            {
-                Debug.Assert(*ptr >= '0' && *ptr <= '9');
-                asize = asize * 10 + *ptr++ - '0';
-                if (ptr >= end)
-                    return false;
-            }
-            ptr += 2;  // for \r\n
-            if (ptr > end)
-                return false;
-
-            if (neg)
-                return true;
-
-            result = new byte[asize][];
-            for (int z = 0; z < asize; z++)
-                if (!ReadByteArrayWithLengthHeader(out result[z], ref ptr, end))
-                    return false;
-
-            return true;
-        }
-
-        /// <summary>
         /// Read string array with length header
         /// </summary>
         public static bool ReadStringArrayWithLengthHeader(out string[] result, ref byte* ptr, byte* end)
@@ -505,47 +469,6 @@ namespace Garnet.common
                     if (!ReadIntegerAsString(out result[z], ref ptr, end))
                         return false;
                 }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Read string array with length header
-        /// </summary>
-        public static bool ReadPtrArrayWithLengthHeader(out List<Tuple<long, long>> result, ref byte* ptr, byte* end)
-        {
-            result = null;
-            if (ptr + 3 >= end)
-                return false;
-
-            Debug.Assert(*ptr == '*');
-            ptr++;
-            bool neg = *ptr == '-';
-            int asize = *ptr++ - '0';
-            while (*ptr != '\r')
-            {
-                Debug.Assert(*ptr >= '0' && *ptr <= '9');
-                asize = asize * 10 + *ptr++ - '0';
-                if (ptr >= end)
-                    return false;
-            }
-            ptr += 2;  // for \r\n
-            if (ptr > end)
-                return false;
-
-            if (neg)
-                return true;
-
-            result = new();
-
-            for (int z = 0; z < asize; z++)
-            {
-                byte* keyPtr = null;
-                int ksize = 0;
-                if (!ReadPtrWithLengthHeader(ref keyPtr, ref ksize, ref ptr, end))
-                    return false;
-                result.Add(new Tuple<long, long>(((IntPtr)keyPtr).ToInt64(), ksize));
             }
 
             return true;

--- a/libs/common/RespReadUtils.cs
+++ b/libs/common/RespReadUtils.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 

--- a/libs/server/Cluster/IClusterSession.cs
+++ b/libs/server/Cluster/IClusterSession.cs
@@ -59,7 +59,7 @@ namespace Garnet.server
         /// <summary>
         /// Single key slot verify (write result to network)
         /// </summary>
-        unsafe bool NetworkSingleKeySlotVerify(byte[] key, bool readOnly, byte SessionAsking, ref byte* dcurr, ref byte* dend);
+        unsafe bool NetworkSingleKeySlotVerify(ReadOnlySpan<byte> key, bool readOnly, byte SessionAsking, ref byte* dcurr, ref byte* dend);
 
         /// <summary>
         /// Single key slot verify (write result to network)

--- a/libs/server/Objects/Hash/HashObject.cs
+++ b/libs/server/Objects/Hash/HashObject.cs
@@ -186,12 +186,12 @@ namespace Garnet.server
             return true;
         }
 
-        private void UpdateSize(byte[] key, byte[] value, bool add = true)
+        private void UpdateSize(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, bool add = true)
         {
             var size = Utility.RoundUp(key.Length, IntPtr.Size) + Utility.RoundUp(value.Length, IntPtr.Size)
                 + (2 * MemoryUtils.ByteArrayOverhead) + MemoryUtils.DictionaryEntryOverhead;
-            this.Size += add ? size : -size;
-            Debug.Assert(this.Size >= MemoryUtils.DictionaryOverhead);
+            Size += add ? size : -size;
+            Debug.Assert(Size >= MemoryUtils.DictionaryOverhead);
         }
 
         /// <inheritdoc />

--- a/libs/server/Objects/List/ListObject.cs
+++ b/libs/server/Objects/List/ListObject.cs
@@ -178,16 +178,16 @@ namespace Garnet.server
                         throw new GarnetException($"Unsupported operation {(ListOperation)_input[0]} in ListObject.Operate");
                 }
 
-                sizeChange = this.Size - previouseSize;
+                sizeChange = Size - previouseSize;
             }
             return true;
         }
 
-        internal void UpdateSize(byte[] item, bool add = true)
+        internal void UpdateSize(ReadOnlySpan<byte> item, bool add = true)
         {
             var size = Utility.RoundUp(item.Length, IntPtr.Size) + MemoryUtils.ByteArrayOverhead + MemoryUtils.ListEntryOverhead;
-            this.Size += add ? size : -size;
-            Debug.Assert(this.Size >= MemoryUtils.ListOverhead);
+            Size += add ? size : -size;
+            Debug.Assert(Size >= MemoryUtils.ListOverhead);
         }
 
         /// <inheritdoc />

--- a/libs/server/Objects/List/ListObjectImpl.cs
+++ b/libs/server/Objects/List/ListObjectImpl.cs
@@ -100,7 +100,7 @@ namespace Garnet.server
                 current = list.Nodes().DefaultIfEmpty(null).FirstOrDefault(i => i.Value.SequenceEqual(pivot));
                 var newNode = current != default ? (fBefore ? list.AddBefore(current, insertitem) : list.AddAfter(current, insertitem)) : default;
                 if (current != null)
-                    this.UpdateSize(insertitem);
+                    UpdateSize(insertitem);
                 _output->opsDone = current != default ? list.Count : -1;
                 _output->countDone = _output->opsDone;
             }
@@ -291,19 +291,21 @@ namespace Garnet.server
 
             for (int c = 0; c < count; c++)
             {
-                if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var value, ref ptr, end))
+                if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var valueSpan, ref ptr, end))
                     return;
 
                 if (c < _input->done)
                     continue;
 
-                //Add the value to the top of the list
-                if (fAddAtHead)
-                    list.AddFirst(value);
-                else
-                    list.AddLast(value);
 
-                this.UpdateSize(value);
+                //Add the value to the top of the list
+                var valueArray = valueSpan.ToArray(); 
+                if (fAddAtHead)
+                    list.AddFirst(valueArray);
+                else
+                    list.AddLast(valueArray);
+
+                UpdateSize(valueSpan);
                 _output->countDone = list.Count;
                 _output->opsDone++;
                 _output->bytesDone = (int)(ptr - startptr);

--- a/libs/server/Objects/Set/SetObject.cs
+++ b/libs/server/Objects/Set/SetObject.cs
@@ -135,11 +135,11 @@ namespace Garnet.server
             return true;
         }
 
-        private void UpdateSize(byte[] item, bool add = true)
+        private void UpdateSize(ReadOnlySpan<byte> item, bool add = true)
         {
             var size = Utility.RoundUp(item.Length, IntPtr.Size) + MemoryUtils.ByteArrayOverhead + MemoryUtils.HashSetEntryOverhead;
-            this.Size += add ? size : -size;
-            Debug.Assert(this.Size >= MemoryUtils.HashSetOverhead);
+            Size += add ? size : -size;
+            Debug.Assert(Size >= MemoryUtils.HashSetOverhead);
         }
 
         /// <inheritdoc />

--- a/libs/server/Objects/Set/SetObjectImpl.cs
+++ b/libs/server/Objects/Set/SetObjectImpl.cs
@@ -32,10 +32,10 @@ namespace Garnet.server
                 if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var member, ref ptr, end))
                     return;
 
-                if (set.Add(member))
+                if (set.Add(member.ToArray()))
                 {
                     _output->countDone++;
-                    this.UpdateSize(member);
+                    UpdateSize(member);
                 }
                 _output->opsDone++;
             }
@@ -118,10 +118,10 @@ namespace Garnet.server
                     continue;
                 }
 
-                if (set.Remove(field))
+                if (set.Remove(field.ToArray()))
                 {
                     countDone++;
-                    this.UpdateSize(field, false);
+                    UpdateSize(field, false);
                 }
 
                 count--;

--- a/libs/server/Objects/SortedSet/SortedSetObject.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObject.cs
@@ -383,13 +383,13 @@ namespace Garnet.server
 
         #endregion
 
-        private void UpdateSize(byte[] item, bool add = true)
+        private void UpdateSize(ReadOnlySpan<byte> item, bool add = true)
         {
             // item's length + overhead to store item + value of type double added to sorted set and dictionary + overhead for those datastructures
             var size = Utility.RoundUp(item.Length, IntPtr.Size) + MemoryUtils.ByteArrayOverhead + (2 * sizeof(double))
                 + MemoryUtils.SortedSetEntryOverhead + MemoryUtils.DictionaryEntryOverhead;
-            this.Size += add ? size : -size;
-            Debug.Assert(this.Size >= MemoryUtils.SortedSetOverhead + MemoryUtils.DictionaryOverhead);
+            Size += add ? size : -size;
+            Debug.Assert(Size >= MemoryUtils.SortedSetOverhead + MemoryUtils.DictionaryOverhead);
         }
     }
 }

--- a/libs/server/Objects/SortedSetGeo/GeoHash.cs
+++ b/libs/server/Objects/SortedSetGeo/GeoHash.cs
@@ -212,7 +212,7 @@ namespace Garnet.server
         /// <param name="value"></param>
         /// <param name="units"></param>
         /// <returns></returns>
-        public static double ConvertValueToMeters(double value, byte[] units)
+        public static double ConvertValueToMeters(double value, ReadOnlySpan<byte> units)
         {
             if (units.Length == 2)
             {
@@ -243,7 +243,7 @@ namespace Garnet.server
         /// <param name="value"></param>
         /// <param name="units"></param>
         /// <returns></returns>
-        public static double ConvertMetersToUnits(double value, byte[] units)
+        public static double ConvertMetersToUnits(double value, ReadOnlySpan<byte> units)
         {
             if (units.Length == 2)
             {

--- a/libs/server/Resp/Objects/HashCommands.cs
+++ b/libs/server/Resp/Objects/HashCommands.cs
@@ -73,7 +73,7 @@ namespace Garnet.server
                 inputPtr->count = inputCount;
                 inputPtr->done = hashOpsCount;
 
-                storageApi.HashSet(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                storageApi.HashSet(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
                 *inputPtr = save; // reset input buffer
 
@@ -165,10 +165,10 @@ namespace Garnet.server
                 if (op == HashOperation.HRANDFIELD)
                 {
                     includeCountParameter = inputPtr->count > 2; // 4 tokens are: command key count WITHVALUES
-                    status = storageApi.HashRandomField(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                    status = storageApi.HashRandomField(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
                 }
                 else
-                    status = storageApi.HashGet(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                    status = storageApi.HashGet(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 // Reset input buffer
                 *inputPtr = save;
@@ -257,7 +257,7 @@ namespace Garnet.server
                 inputPtr->count = 1;
                 inputPtr->done = 0;
 
-                var status = storageApi.HashLength(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                var status = storageApi.HashLength(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
                 // Restore input buffer
                 *inputPtr = save;
@@ -327,7 +327,7 @@ namespace Garnet.server
                 inputPtr->count = 1;
                 inputPtr->done = 0;
 
-                var status = storageApi.HashStrLength(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                var status = storageApi.HashStrLength(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
                 // Restore input buffer
                 *inputPtr = save;
@@ -401,7 +401,7 @@ namespace Garnet.server
                 inputPtr->count = inputCount;
                 inputPtr->done = hashItemsDoneCount;
 
-                var status = storageApi.HashDelete(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+                var status = storageApi.HashDelete(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out var output);
 
                 // Restore input buffer
                 *inputPtr = save;
@@ -478,7 +478,7 @@ namespace Garnet.server
                 inputPtr->count = 1;
                 inputPtr->done = 0;
 
-                var status = storageApi.HashExists(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+                var status = storageApi.HashExists(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out var output);
 
                 // Restore input buffer
                 *inputPtr = save;
@@ -556,9 +556,9 @@ namespace Garnet.server
             GarnetStatus status = GarnetStatus.NOTFOUND;
 
             if (op == HashOperation.HKEYS)
-                status = storageApi.HashKeys(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                status = storageApi.HashKeys(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
             else
-                status = storageApi.HashVals(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                status = storageApi.HashVals(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
             // Restore input buffer
             *inputPtr = save;
@@ -641,7 +641,7 @@ namespace Garnet.server
                 // Prepare GarnetObjectStore output
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
 
-                var status = storageApi.HashIncrement(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.HashIncrement(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 // Restore input
                 *inputPtr = save;

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -75,9 +75,9 @@ namespace Garnet.server
             var status = GarnetStatus.OK;
 
             if (lop == ListOperation.LPUSH || lop == ListOperation.LPUSHX)
-                status = storageApi.ListLeftPush(sskey, input, out output);
+                status = storageApi.ListLeftPush(sskey.ToArray(), input, out output);
             else
-                status = storageApi.ListRightPush(sskey, input, out output);
+                status = storageApi.ListRightPush(sskey.ToArray(), input, out output);
 
             //restore input buffer
             *inputPtr = save;
@@ -166,9 +166,9 @@ namespace Garnet.server
             GarnetStatus statusOp = GarnetStatus.NOTFOUND;
 
             if (lop == ListOperation.LPOP)
-                statusOp = storageApi.ListLeftPop(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                statusOp = storageApi.ListLeftPop(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
             else
-                statusOp = storageApi.ListRightPop(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                statusOp = storageApi.ListRightPop(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
             // Reset input buffer
             *inputPtr = save;
@@ -236,7 +236,7 @@ namespace Garnet.server
                 inputPtr->count = count;
                 inputPtr->done = 0;
 
-                var status = storageApi.ListLength(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+                var status = storageApi.ListLength(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out var output);
 
                 //restore input buffer
                 *inputPtr = save;
@@ -313,7 +313,7 @@ namespace Garnet.server
                 inputPtr->count = start;
                 inputPtr->done = stop;
 
-                var statusOp = storageApi.ListTrim(key, new ArgSlice((byte*)inputPtr, inputLength));
+                var statusOp = storageApi.ListTrim(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength));
 
                 //restore input buffer
                 *inputPtr = save;
@@ -381,7 +381,7 @@ namespace Garnet.server
                 inputPtr->count = start;
                 inputPtr->done = end;
 
-                var statusOp = storageApi.ListRange(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var statusOp = storageApi.ListRange(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 // Reset input buffer
                 *inputPtr = save;
@@ -455,7 +455,7 @@ namespace Garnet.server
                 inputPtr->count = index;
                 inputPtr->done = 0;
 
-                var statusOp = storageApi.ListIndex(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var statusOp = storageApi.ListIndex(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 //restore input
                 *inputPtr = save;
@@ -530,7 +530,7 @@ namespace Garnet.server
                 inputPtr->done = 0;
                 inputPtr->count = 0;
 
-                var statusOp = storageApi.ListInsert(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+                var statusOp = storageApi.ListInsert(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out var output);
 
                 //restore input buffer
                 *inputPtr = save;
@@ -617,7 +617,7 @@ namespace Garnet.server
                 inputPtr->count = nCount;
                 inputPtr->done = 0;
 
-                var statusOp = storageApi.ListRemove(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                var statusOp = storageApi.ListRemove(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
                 //restore input buffer
                 *inputPtr = save;
 

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -70,7 +70,7 @@ namespace Garnet.server
                 inputPtr->count = inputCount;
                 inputPtr->done = setOpsCount;
 
-                storageApi.SetAdd(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                storageApi.SetAdd(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
                 // Restore input buffer
                 *inputPtr = save;
@@ -142,7 +142,7 @@ namespace Garnet.server
                 inputPtr->count = inputCount;
                 inputPtr->done = setItemsDoneCount;
 
-                var status = storageApi.SetRemove(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+                var status = storageApi.SetRemove(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out var output);
 
                 // Restore input buffer
                 *inputPtr = save;
@@ -222,7 +222,7 @@ namespace Garnet.server
                 inputPtr->count = 1;
                 inputPtr->done = 0;
 
-                var status = storageApi.SetLength(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+                var status = storageApi.SetLength(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out var output);
 
                 // Restore input buffer
                 *inputPtr = save;
@@ -292,7 +292,7 @@ namespace Garnet.server
                 // Prepare GarnetObjectStore output
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
 
-                var status = storageApi.SetMembers(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.SetMembers(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 // Restore input buffer
                 *inputPtr = save;
@@ -408,7 +408,7 @@ namespace Garnet.server
             // Prepare GarnetObjectStore output
             var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
 
-            var status = storageApi.SetPop(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+            var status = storageApi.SetPop(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
             // Reset input buffer
             *inputPtr = save;

--- a/libs/server/Resp/Objects/SharedObjectCommands.cs
+++ b/libs/server/Resp/Objects/SharedObjectCommands.cs
@@ -101,7 +101,7 @@ namespace Garnet.server
 
                 // Prepare GarnetObjectStore output
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
-                var status = storageApi.ObjectScan(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.ObjectScan(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 //restore input buffer
                 *inputPtr = save;

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -78,7 +78,7 @@ namespace Garnet.server
             inputPtr->count = inputCount;
             inputPtr->done = zaddDoneCount;
 
-            storageApi.SortedSetAdd(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+            storageApi.SortedSetAdd(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
             // Reset input buffer
             *inputPtr = save;
@@ -147,7 +147,7 @@ namespace Garnet.server
                 rmwInput->count = inputCount;
                 rmwInput->done = zaddDoneCount;
 
-                var status = storageApi.SortedSetRemove(key, new ArgSlice((byte*)rmwInput, inputLength), out ObjectOutputHeader rmwOutput);
+                var status = storageApi.SortedSetRemove(key.ToArray(), new ArgSlice((byte*)rmwInput, inputLength), out ObjectOutputHeader rmwOutput);
 
                 // Reset input buffer
                 *rmwInput = save;
@@ -230,7 +230,7 @@ namespace Garnet.server
                 inputPtr->count = 1;
                 inputPtr->done = 0;
 
-                var status = storageApi.SortedSetLength(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+                var status = storageApi.SortedSetLength(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out var output);
 
                 // Reset input buffer
                 *inputPtr = save;
@@ -318,7 +318,7 @@ namespace Garnet.server
 
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
 
-                var status = storageApi.SortedSetRange(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.SortedSetRange(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 // Reset input buffer
                 *inputPtr = save;
@@ -418,7 +418,7 @@ namespace Garnet.server
                 // Prepare GarnetObjectStore output
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
 
-                var status = storageApi.SortedSetScore(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.SortedSetScore(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 //restore input
                 *inputPtr = save;
@@ -492,7 +492,7 @@ namespace Garnet.server
                 // Prepare GarnetObjectStore output
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
 
-                var status = storageApi.SortedSetScores(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.SortedSetScores(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 //restore input
                 *inputPtr = save;
@@ -579,7 +579,7 @@ namespace Garnet.server
                 // Prepare output
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(SpanByte.FromPointer(dcurr, (int)(dend - dcurr))) };
 
-                var status = storageApi.SortedSetPop(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.SortedSetPop(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 //restore input buffer
                 *inputPtr = save;
@@ -653,7 +653,7 @@ namespace Garnet.server
                 inputPtr->count = 0;
                 inputPtr->done = 0;
 
-                var status = storageApi.SortedSetCount(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                var status = storageApi.SortedSetCount(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
                 //restore input buffer
                 *inputPtr = save;
@@ -745,8 +745,8 @@ namespace Garnet.server
                 inputPtr->done = 0;
 
                 var status = op == SortedSetOperation.ZREMRANGEBYLEX ?
-                             storageApi.SortedSetRemoveRangeByLex(key, new ArgSlice((byte*)inputPtr, inputLength), out var output) :
-                             storageApi.SortedSetLengthByValue(key, new ArgSlice((byte*)inputPtr, inputLength), out output);
+                             storageApi.SortedSetRemoveRangeByLex(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out var output) :
+                             storageApi.SortedSetLengthByValue(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out output);
 
                 //restore input buffer
                 *inputPtr = save;
@@ -832,7 +832,7 @@ namespace Garnet.server
                 // Prepare GarnetObjectStore output
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
 
-                var status = storageApi.SortedSetIncrement(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.SortedSetIncrement(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 //restore input
                 *inputPtr = save;
@@ -932,7 +932,7 @@ namespace Garnet.server
                 inputPtr->count = memberSize;
                 inputPtr->done = 0;
 
-                var status = storageApi.SortedSetRank(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                var status = storageApi.SortedSetRank(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
                 // Reset input buffer
                 *inputPtr = save;
@@ -1004,7 +1004,7 @@ namespace Garnet.server
                 inputPtr->count = 0;
                 inputPtr->done = 0;
 
-                var status = storageApi.SortedSetRemoveRange(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                var status = storageApi.SortedSetRemoveRange(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
                 //restore input buffer
                 *inputPtr = save;
@@ -1073,7 +1073,7 @@ namespace Garnet.server
 
                 var paramCount = 0;
                 ReadOnlySpan<byte> withScoresSpan = "WITHSCORES"u8;
-                Byte[] includeWithScores = default;
+                ReadOnlySpan<byte> includeWithScores = default;
 
                 bool includedCount = false;
 
@@ -1088,8 +1088,10 @@ namespace Garnet.server
                     // Read withscores
                     if (count == 3)
                     {
+#pragma warning disable CS9087 // This returns a parameter by reference but it is not a ref parameter
                         if (!RespReadUtils.ReadByteArrayWithLengthHeader(out includeWithScores, ref ptr, recvBufferPtr + bytesRead))
                             return false;
+#pragma warning restore CS9087 // This returns a parameter by reference but it is not a ref parameter
                     }
                 }
 
@@ -1116,7 +1118,7 @@ namespace Garnet.server
                 {
                     // Prepare GarnetObjectStore output
                     outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
-                    status = storageApi.SortedSetRandomMember(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                    status = storageApi.SortedSetRandomMember(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
                 }
 
                 //restore input buffer

--- a/libs/server/Resp/Objects/SortedSetGeoCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetGeoCommands.cs
@@ -57,7 +57,7 @@ namespace Garnet.server
                 inputPtr->count = inputCount;
                 inputPtr->done = zaddDoneCount;
 
-                var status = storageApi.GeoAdd(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                var status = storageApi.GeoAdd(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
                 //restore input buffer
                 *inputPtr = save;
@@ -162,7 +162,7 @@ namespace Garnet.server
 
                 var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
 
-                var status = storageApi.GeoCommands(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+                var status = storageApi.GeoCommands(key.ToArray(), new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
 
                 //restore input buffer
                 *inputPtr = save;

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -878,7 +878,7 @@ namespace Garnet.server
         /// <param name="key">Key bytes</param>
         /// <param name="readOnly">Whether caller is going to perform a readonly or read/write operation.</param>
         /// <returns>True when ownernship is verified, false otherwise</returns>
-        bool NetworkSingleKeySlotVerify(byte[] key, bool readOnly)
+        bool NetworkSingleKeySlotVerify(ReadOnlySpan<byte> key, bool readOnly)
             => clusterSession != null && clusterSession.NetworkSingleKeySlotVerify(key, readOnly, SessionAsking, ref dcurr, ref dend);
 
         /// <summary>


### PR DESCRIPTION
previewing proper PR splits to keep it reviewable.

todo: do the changes in "reverse order" to reduce any potential confusion, meaning that the final commit should be the `RespReadUtils` which kills all the allocations.

also kill linq usage where appropiate

also check what the the dictionary/hashset span `MappedLookup<T, TAlternateKey>` that we get in .NET 9 is gonna look like. It should kill a lot of remaining allocations and defer the allocations to only exist where we need to insert stuff